### PR TITLE
Replace gmcs with mcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 BINARY=RogueSurvivor.exe
 TEST_BIN=test_$(BINARY)
 
-CS=gmcs
+CS=mcs
 CSFLAGS = -pkg:dotnet \
 	      -define:LINUX
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BUILDING
 You will need ```gmcs``` and the System libraries to compile. Here are the
 Debian/Ubuntu packages you'll need:
 ```
-mono-gmcs
+mono-mcs
 mono-devel
 ```
 


### PR DESCRIPTION
GMCS seems to have been replaced with MCS. Mono no longer ships it, and is not present in the repo of Ubuntu anymore. With mcs it compiles with the following errors, which I assume is the same as gmcs.

```
src/Engine/RogueGame/RogueGame.cs(983,41): warning CS0219: The variable `zombifiedHP' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(985,43): warning CS0219: The variable `zombified' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(4644,31): warning CS0219: The variable `command' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(4738,31): warning CS0219: The variable `command' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(10643,26): warning CS0219: The variable `objLoc' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(11527,20): warning CS0219: The variable `hisOrHer' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.cs(12031,31): warning CS0219: The variable `command' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.Rendering.cs(696,19): warning CS0219: The variable `offset' is assigned but its value is never used
src/Engine/RogueGame/RogueGame.Rendering.cs(720,19): warning CS0219: The variable `offset' is assigned but its value is never used
src/RogueForm.Designer.cs(40,60): warning CS0219: The variable `resources' is assigned but its value is never used
src/Gameplay/AI/CHARGuardAI.cs(136,23): warning CS0219: The variable `targetActor' is assigned but its value is never used
src/Gameplay/AI/CivilianAI.cs(246,18): warning CS0472: The result of comparing value type `djack.RogueSurvivor.Data.Location' with null is always `true'
src/Engine/RogueGame/RogueGame.cs(71,17): warning CS0649: Field `djack.RogueSurvivor.Engine.RogueGame.m_CharGen' is never assigned to, and will always have its default value
src/UI/GDIGameCanvas.cs(30,16): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIGameCanvas.m_MinimapBitmap' is assigned but its value is never used
src/UI/GDIGameCanvas.cs(323,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIGameCanvas.GfxTransparentImage.m_Alpha' is assigned but its value is never used
src/UI/GDIGameCanvas.cs(375,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIGameCanvas.GfxString.m_Color' is assigned but its value is never used
src/UI/GDIGameCanvas.cs(323,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIGameCanvas.GfxTransparentImage.m_Alpha' is assigned but its value is never used
src/UI/GDIGameCanvas.cs(375,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIGameCanvas.GfxString.m_Color' is assigned but its value is never used
src/UI/GDIPlusGameCanvas.cs(408,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIPlusGameCanvas.GfxTransparentImage.m_Alpha' is assigned but its value is never used
src/UI/GDIPlusGameCanvas.cs(460,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIPlusGameCanvas.GfxString.m_Color' is assigned but its value is never used
src/UI/GDIPlusGameCanvas.cs(408,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIPlusGameCanvas.GfxTransparentImage.m_Alpha' is assigned but its value is never used
src/UI/GDIPlusGameCanvas.cs(460,28): warning CS0414: The private field `djack.RogueSurvivor.UI.GDIPlusGameCanvas.GfxString.m_Color' is assigned but its value is never used
src/Gameplay/GameTiles.cs(48,31): warning CS0414: The private field `djack.RogueSurvivor.Gameplay.GameTiles.DRK_GRAY2' is assigned but its value is never used
Compilation succeeded - 23 warning(s)

```